### PR TITLE
rcar_gen3: refactor pinmux

### DIFF
--- a/boards/arm/rcar_ebisu/pinmux.c
+++ b/boards/arm/rcar_ebisu/pinmux.c
@@ -4,41 +4,23 @@
  */
 
 #include <init.h>
-#include <drivers/pinmux.h>
+#include <soc.h>
 #include <pinmux/pinmux_rcar.h>
 
- static int rcar_ebisu_pinmux_init(const struct device *dev)
- {
+static int rcar_ebisu_pinmux_init(const struct device *dev)
+{
 	 ARG_UNUSED(dev);
 
-	 const struct device *pfc =
-		 device_get_binding(DT_LABEL(DT_NODELABEL(pfc)));
-	 __ASSERT(pfc, "Fail to get pincontrol device");
-	 /* Make compiler happy if pfc is not used */
-	 (void) pfc;
-
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(can0), okay) && CONFIG_CAN
-	 /* CAN0_TX */
-	 pinmux_rcar_set_gpsr(pfc, 0, 12, true);
-	 pinmux_rcar_set_ipsr(pfc, 7, 4, 3);
-
-	 /* CAN0_RX */
-	 pinmux_rcar_set_gpsr(pfc, 0, 13, true);
-	 pinmux_rcar_set_ipsr(pfc, 7, 8, 3);
+	 pinmux_rcar_set_pingroup(can0_data, ARRAY_SIZE(can0_data));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(scif2), okay) && CONFIG_SERIAL
 	/* SCIF2 = UBOOT OUTPUT */
-	/* SCIF2_RX */
-	pinmux_rcar_set_gpsr(pfc, 5, 9, true);
-	pinmux_rcar_set_ipsr(pfc, 12, 12, 0);
-
-	/* SCIF2_TX */
-	pinmux_rcar_set_gpsr(pfc, 5, 8, true);
-	pinmux_rcar_set_ipsr(pfc, 12, 8, 0);
+	 pinmux_rcar_set_pingroup(scif2_data_a, ARRAY_SIZE(scif2_data_a));
 #endif
 
 	 return 0;
- }
+}
 
 SYS_INIT(rcar_ebisu_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);

--- a/boards/arm/rcar_ulcb/pinmux.c
+++ b/boards/arm/rcar_ulcb/pinmux.c
@@ -4,47 +4,25 @@
  */
 
 #include <init.h>
-#include <drivers/pinmux.h>
+#include <soc.h>
 #include <pinmux/pinmux_rcar.h>
 
  static int rcar_ulcb_pinmux_init(const struct device *dev)
  {
 	 ARG_UNUSED(dev);
 
-	 const struct device *pfc =
-		 device_get_binding(DT_LABEL(DT_NODELABEL(pfc)));
-	 __ASSERT(pfc, "Fail to get pincontrol device");
-
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(can0), okay) && CONFIG_CAN
-	/* CAN0_TX */
-	pinmux_rcar_set_gpsr(pfc, 1, 23, true);
-	pinmux_rcar_set_ipsr(pfc, 4, 24, 8);
-
-	/* CAN0_RX */
-	pinmux_rcar_set_gpsr(pfc, 1, 24, true);
-	pinmux_rcar_set_ipsr(pfc, 4, 28, 8);
+	 pinmux_rcar_set_pingroup(can0_data_a, ARRAY_SIZE(can0_data_a));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(scif1), okay) && CONFIG_SERIAL
 	/* SCIF1 = SECONDARY SERIAL PORT */
-	/* SCIF1_RX */
-	pinmux_rcar_set_gpsr(pfc, 5, 5, true);
-	pinmux_rcar_set_ipsr(pfc, 12, 12, 0);
-
-	/* SCIF1_TX */
-	pinmux_rcar_set_gpsr(pfc, 5, 6, true);
-	pinmux_rcar_set_ipsr(pfc, 12, 16, 0);
+	 pinmux_rcar_set_pingroup(scif1_data_a, ARRAY_SIZE(scif1_data_a));
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(scif2), okay) && CONFIG_SERIAL
 	/* SCIF2 = UBOOT OUTPUT */
-	/* SCIF2_RX */
-	pinmux_rcar_set_gpsr(pfc, 5, 11, true);
-	pinmux_rcar_set_ipsr(pfc, 13, 4, 0);
-
-	/* SCIF2_TX */
-	pinmux_rcar_set_gpsr(pfc, 5, 10, true);
-	pinmux_rcar_set_ipsr(pfc, 13, 0, 0);
+	 pinmux_rcar_set_pingroup(scif2_data_a, ARRAY_SIZE(scif2_data_a));
 #endif
 
 	return 0;

--- a/drivers/pinmux/pinmux_rcar.c
+++ b/drivers/pinmux/pinmux_rcar.c
@@ -6,99 +6,54 @@
 
 #define DT_DRV_COMPAT renesas_rcar_pinmux
 
-#include <errno.h>
-#include <device.h>
-#include <drivers/pinmux.h>
+#include <devicetree.h>
 #include <soc.h>
+#include <device.h>
 
+#define PINMUX_REG_BASE  DT_INST_REG_ADDR(0)
 #define PINMUX_RCAR_PMMR 0x0
 #define PINMUX_RCAR_GPSR 0x100
 #define PINMUX_RCAR_IPSR 0x200
 
-struct pinmux_rcar_config {
-	uint32_t reg_addr;
-};
-
 /* Any write to IPSR or GPSR must be precede to a write to PMMR with 
  * the inverse value.
  */
-static void pinmux_rcar_write(const struct pinmux_rcar_config *config,
-			      uint32_t offs, uint32_t val)
+static void pinmux_rcar_write(uint32_t offs, uint32_t val)
 {
-	sys_write32(~val, config->reg_addr + PINMUX_RCAR_PMMR);
-	sys_write32(val, config->reg_addr + offs);
+	sys_write32(~val, PINMUX_REG_BASE + PINMUX_RCAR_PMMR);
+	sys_write32(val, PINMUX_REG_BASE + offs);
 }
 
 /* Set the pin either in gpio or peripheral */
-void pinmux_rcar_set_gpsr(const struct device *dev,
-		       uint8_t gpsr, uint8_t pos, bool peripheral)
+static void pinmux_rcar_set_gpsr(uint8_t bank, uint8_t pos, bool peripheral)
 {
-	const struct pinmux_rcar_config *config = dev->config;
-	uint32_t val = sys_read32(config->reg_addr + PINMUX_RCAR_GPSR +
-				  gpsr * sizeof(uint32_t));
+	uint32_t reg = sys_read32(PINMUX_REG_BASE + PINMUX_RCAR_GPSR +
+				  bank * sizeof(uint32_t));
 	if (peripheral)
-		val |= BIT(pos);
+		reg |= BIT(pos);
 	else
-		val &= ~BIT(pos);
-	pinmux_rcar_write(config, PINMUX_RCAR_GPSR + gpsr * sizeof(uint32_t),
-			  val);
+		reg &= ~BIT(pos);
+	pinmux_rcar_write(PINMUX_RCAR_GPSR + bank * sizeof(uint32_t), reg);
 }
 
-void pinmux_rcar_set_ipsr(const struct device *dev,
-				 uint8_t ipsr, uint8_t pos, uint32_t val)
+/* Set peripheral function */
+static void pinmux_rcar_set_ipsr(uint8_t bank, uint8_t shift, uint8_t val)
 {
-	const struct pinmux_rcar_config *config = dev->config;
-	uint32_t reg = sys_read32(config->reg_addr + PINMUX_RCAR_IPSR +
-				  ipsr * sizeof(uint32_t));
-	reg &= ~(0xF << pos);
-	reg |= (val << pos);
-	pinmux_rcar_write(config, PINMUX_RCAR_IPSR + ipsr * sizeof(uint32_t),
-			  reg);
+	uint32_t reg = sys_read32(PINMUX_REG_BASE + PINMUX_RCAR_IPSR +
+				  bank * sizeof(uint32_t));
+	reg &= ~(0xF << shift);
+	reg |= (val << shift);
+	pinmux_rcar_write(PINMUX_RCAR_IPSR + bank * sizeof(uint32_t), reg);
 }
-	
-static int pinmux_rcar_set(const struct device *dev, uint32_t pin,
-			     uint32_t func)
+
+void pinmux_rcar_set_pingroup(const struct rcar_pin *pins, size_t num_pins)
 {
-	return -ENOTSUP;
+	size_t i;
+
+	for (i = 0; i < num_pins; i++, pins++) {
+		pinmux_rcar_set_gpsr(pins->gpsr_bank, pins->gpsr_num,
+				     pins->gpsr_val);
+		pinmux_rcar_set_ipsr(pins->ipsr_bank, pins->ipsr_shift,
+				     pins->ipsr_val);
+	}
 }
-
-static int pinmux_rcar_get(const struct device *dev, uint32_t pin,
-			     uint32_t *func)
-{
-	return -ENOTSUP;
-}
-	
-static int pinmux_rcar_pullup(const struct device *dev, uint32_t pin,
-				uint8_t func)
-{
-	return -ENOTSUP;
-}
-
-static int pinmux_rcar_input(const struct device *dev, uint32_t pin,
-			       uint8_t func)
-{
-	return -ENOTSUP;
-}
-
-static int pinmux_rcar_init(const struct device *dev)
-{
-	return 0;
-}
-
-static const struct pinmux_driver_api pinmux_rcar_driver_api = {
-	.set = pinmux_rcar_set,
-	.get = pinmux_rcar_get,
-	.pullup = pinmux_rcar_pullup,
-	.input = pinmux_rcar_input,
-};
-
-static const struct pinmux_rcar_config pinmux_rcar_0_config = { 
-		.reg_addr = DT_INST_REG_ADDR(0),	       
-};							       
-
-DEVICE_DT_INST_DEFINE(0, &pinmux_rcar_init,
-			    device_pm_control_nop,
-			    NULL, &pinmux_rcar_0_config,
-			    PRE_KERNEL_1,
-			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
-			    &pinmux_rcar_driver_api);

--- a/drivers/pinmux/pinmux_rcar.h
+++ b/drivers/pinmux/pinmux_rcar.h
@@ -6,12 +6,8 @@
 
 #ifndef ZEPHYR_DRIVERS_PINMUX_RCAR_H_
 #define ZEPHYR_DRIVERS_PINMUX_RCAR_H_
+#include <soc.h>
 
-struct device *dev;
+void pinmux_rcar_set_pingroup(const struct rcar_pin *pins, size_t num_pins);
 
-void pinmux_rcar_set_gpsr(const struct device *dev,
-			  uint8_t gpsr, uint8_t pos, bool peripheral);
-
-void pinmux_rcar_set_ipsr(const struct device *dev,
-			  uint8_t ipsr, uint8_t pos, uint32_t val);
 #endif /* ZEPHYR_DRIVERS_PINMUX_RCAR_H_ */

--- a/soc/arm/renesas_rcar/gen3/pfc-r8a77951.h
+++ b/soc/arm/renesas_rcar/gen3/pfc-r8a77951.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _PFC_RCAR_R8A77951_
+#define _PFC_RCAR_R8A77951_
+#include "pfc-rcar.h"
+
+static const struct rcar_pin can0_data_a[] = {
+	/* TX, RX */
+	{4, 24, 8, 1, 23, true}, {4, 28, 8, 1, 24, true},
+};
+
+static const struct rcar_pin scif1_data_a[] = {
+	/* TX, RX */
+	{12, 16, 0, 5, 6, true}, {12, 12, 0, 5, 5, true},
+};
+
+static const struct rcar_pin scif2_data_a[] = {
+	/* TX, RX */
+	{13, 0, 0, 5, 10, true}, {13, 4, 0, 5, 11, true},
+};
+
+#endif /* _PFC_RCAR_R8A77951_ */

--- a/soc/arm/renesas_rcar/gen3/pfc-r8a77990.h
+++ b/soc/arm/renesas_rcar/gen3/pfc-r8a77990.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _PFC_RCAR_R8A77990_
+#define _PFC_RCAR_R8A77990_
+#include "pfc-rcar.h"
+
+static const struct rcar_pin can0_data[] = {
+	/* TX, RX */
+	{7, 4, 3, 0, 12, true}, {7, 8, 3, 0, 13, true},
+};
+
+static const struct rcar_pin scif2_data_a[] = {
+	/* TX, RX */
+	{12, 8, 0, 5, 8, true}, {12, 12, 0, 5, 9, true},
+};
+
+#endif /* _PFC_RCAR_R8A77990_ */

--- a/soc/arm/renesas_rcar/gen3/pfc-rcar.h
+++ b/soc/arm/renesas_rcar/gen3/pfc-rcar.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _PFC_RCAR__H_
+#define _PFC_RCAR__H_
+#include <stdint.h>
+#include <stdbool.h>
+
+struct rcar_pin {
+	/* select pin function */
+	uint8_t ipsr_bank; /* bank number 0 - 18 */
+	uint8_t ipsr_shift; /* bit shift 0 - 28 */
+	uint8_t ipsr_val; /* choice from 0x0 to 0xF */
+	/* Select gpio or function */
+	uint8_t gpsr_bank; /* bank number 0 - 7 */
+	uint8_t gpsr_num; /* pin index < 32 */
+	bool    gpsr_val; /* gpio:false, peripheral:true */
+};
+
+#endif /* _PFC_RCAR__H_ */

--- a/soc/arm/renesas_rcar/gen3/soc.h
+++ b/soc/arm/renesas_rcar/gen3/soc.h
@@ -15,4 +15,10 @@
 #define __GIC_PRESENT 0
 #define __TIM_PRESENT 0
 
+#if defined(CONFIG_SOC_R8A77951)
+#include "pfc-r8a77951.h"
+#elif defined(CONFIG_SOC_R8A77990)
+#include "pfc-r8a77990.h"
+#endif
+
 #endif /* _SOC__H_ */


### PR DESCRIPTION
This intend to make more sense on how pinmux configuration is designed.

Pins are now declared as group for example can0_data_a group are pins
in order to enable can function on pins can0_a pins (rx,tx).

Pins details about configuring GPSR and IPSR registers are now defined
at soc level (pfc-r8a779xx.h) so the board only need to select the
required pin set.

pinmux_rcar driver no longer pretend to be a regular zephyr pinmux driver,
instead we make available pinmux_rcar_set_pingroup api that board are
supposed to call early in order to set all the required pin configuration.

Let see how this new way to set function will scale in the future, and
how we will manage new feature like pull up, or pin voltage level.