### PR TITLE
boards: arm: ulcb: set default shell output

### DIFF
--- a/boards/arm/rcar_ulcb/rcar_ulcb_cr7.dts
+++ b/boards/arm/rcar_ulcb/rcar_ulcb_cr7.dts
@@ -18,6 +18,7 @@
 		zephyr,ipc = &mfis;
 		zephyr,can-primary = &can0;
 		zephyr,console = &scif1;
+		zephyr,shell-uart = &scif1;
 	};
 
 	sram_shm: memory@42000000 {


### PR DESCRIPTION
Add default shell output for ulcb board.
Allow user to deploy shell easier.

Signed-off-by: Aymeric Aillet <aymeric.aillet@iot.bzh>