### PR TITLE
soc: renesas_rcar: gen3: enable L1 cache and branch prediction

### DIFF
--- a/soc/arm/renesas_rcar/gen3/Kconfig.series
+++ b/soc/arm/renesas_rcar/gen3/Kconfig.series
@@ -5,6 +5,7 @@ config SOC_SERIES_RCAR_GEN3
 	bool "Renesas RCAR Gen3 Cortex R7"
 	select ARM
 	select CPU_CORTEX_R7
+	select PLATFORM_SPECIFIC_INIT
 	select GIC_V2
 	select CPU_HAS_DCLS
 	select SOC_FAMILY_RCAR

--- a/soc/arm/renesas_rcar/gen3/soc.c
+++ b/soc/arm/renesas_rcar/gen3/soc.c
@@ -28,4 +28,18 @@ static int soc_init(const struct device *arg)
 	return 0;
 }
 
+void z_platform_init(void)
+{
+	L1C_DisableCaches();
+	L1C_DisableBTAC();
+
+	/* Invalidate instruction cache and flush branch target cache */
+	L1C_InvalidateICacheAll();
+	L1C_InvalidateDCacheAll();
+	L1C_InvalidateBTAC();
+
+	L1C_EnableCaches();
+	L1C_EnableBTAC();
+}
+
 SYS_INIT(soc_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Use CMSIS abstraction to enable L1 cache and branch prediction.

Signed-off-by: Julien Massot <julien.massot@iot.bzh>