### PR TITLE
drivers: i2c: Rework using interrupts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -225,6 +225,7 @@
 /drivers/i2c/i2c_common.c                 @sjg20
 /drivers/i2c/i2c_emul.c                   @sjg20
 /drivers/i2c/i2c_ite_it8xxx2.c            @GTLin08
+/drivers/i2c/i2c_rcar.c                   @aaillet
 /drivers/i2c/i2c_shell.c                  @nashif
 /drivers/i2c/Kconfig.i2c_emul             @sjg20
 /drivers/i2c/Kconfig.it8xxx2              @GTLin08

--- a/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
@@ -113,6 +113,9 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0xe6510000 0x40>;
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 286 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
 			clocks = <&cpg CPG_MOD 929>;
 			status = "disabled";
 			label = "i2c2";

--- a/dts/bindings/i2c/renesas,rcar-i2c.yaml
+++ b/dts/bindings/i2c/renesas,rcar-i2c.yaml
@@ -10,5 +10,7 @@ include: i2c-controller.yaml
 properties:
     reg:
       required: true
+    interrupts:
+      required: true
     clocks:
       required: true


### PR DESCRIPTION
Replace old polling logic by interrupts driven waits.
I2C waits are no longer blocking the core running Zephyr.

Tested on H3ULCB (on top of KF daughter board).
Got same result as old validated polling version of the driver.
Uncrustify corrected driver.

Signed-off-by: Aymeric Aillet <aymeric.aillet@iot.bzh>