### PR TITLE
Iotbzh/aymeric/irq uart fix

### DIFF
--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -183,16 +183,6 @@ static int uart_rcar_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	/* Disable Transmit and Receive */
-	reg_val = uart_rcar_read_16(config, SCSCR);
-	reg_val &= ~(SCSCR_TE | SCSCR_RE);
-	uart_rcar_write_16(config, SCSCR, reg_val);
-
-	/* Emptying Transmit and Receive FIFO */
-	reg_val = uart_rcar_read_16(config, SCFCR);
-	reg_val |= (SCFCR_TFRST | SCFCR_RFRST);
-	uart_rcar_write_16(config, SCFCR, reg_val);
-
 	/* Resetting Errors Registers */
 	reg_val = uart_rcar_read_16(config, SCFSR);
 	reg_val &= ~(SCFSR_ER | SCFSR_DR | SCFSR_BRK | SCFSR_RDF);
@@ -222,9 +212,8 @@ static int uart_rcar_configure(const struct device *dev,
 		     SCFCR_MCE | SCFCR_TFRST | SCFCR_RFRST);
 	uart_rcar_write_16(config, SCFCR, reg_val);
 
-	/* Enable Transmit & Receive + disable Interrupts */
+	/* Disable Interrupts */
 	reg_val = uart_rcar_read_16(config, SCSCR);
-	reg_val |= (SCSCR_TE | SCSCR_RE);
 	reg_val &= ~(SCSCR_TIE | SCSCR_RIE | SCSCR_TEIE | SCSCR_REIE |
 		     SCSCR_TOIE);
 	uart_rcar_write_16(config, SCSCR, reg_val);
@@ -251,6 +240,7 @@ static int uart_rcar_init(const struct device *dev)
 	const struct uart_rcar_cfg *config = DEV_UART_CFG(dev);
 	struct uart_rcar_data *data = DEV_UART_DATA(dev);
 	int ret;
+	uint16_t reg_val;
 
 	ret = clock_control_on(config->clock_dev,
 			       (clock_control_subsys_t *)&config->mod_clk);
@@ -265,7 +255,23 @@ static int uart_rcar_init(const struct device *dev)
 		return ret;
 	}
 
+	/* Disable Transmit and Receive */
+	reg_val = uart_rcar_read_16(config, SCSCR);
+	reg_val &= ~(SCSCR_TE | SCSCR_RE);
+	uart_rcar_write_16(config, SCSCR, reg_val);
+
+	/* Emptying Transmit and Receive FIFO */
+	reg_val = uart_rcar_read_16(config, SCFCR);
+	reg_val |= (SCFCR_TFRST | SCFCR_RFRST);
+	uart_rcar_write_16(config, SCFCR, reg_val);
+
 	ret = uart_rcar_configure(dev, &data->current_config);
+
+	/* Enable Transmit and Receive */
+	reg_val = uart_rcar_read_16(config, SCSCR);
+	reg_val |= (SCSCR_TE | SCSCR_RE);
+	uart_rcar_write_16(config, SCSCR, reg_val);
+
 	if (ret != 0) {
 		return ret;
 	}

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -300,12 +300,12 @@ static int uart_rcar_fifo_fill(const struct device *dev,
 		/* Send current byte */
 		uart_rcar_write_8(config, SCFTDR, tx_data[num_tx]);
 
+		reg_val = uart_rcar_read_16(config, SCFSR);
+		reg_val &= ~(SCFSR_TDFE | SCFSR_TEND);
+		uart_rcar_write_16(config, SCFSR, reg_val);
+
 		num_tx++;
 	}
-
-	reg_val = uart_rcar_read_16(config, SCFSR);
-	reg_val &= ~(SCFSR_TDFE | SCFSR_TEND);
-	uart_rcar_write_16(config, SCFSR, reg_val);
 
 	return num_tx;
 }
@@ -321,11 +321,11 @@ static int uart_rcar_fifo_read(const struct device *dev, uint8_t *rx_data,
 	       (uart_rcar_read_16(config, SCFSR) & SCFSR_RDF)) {
 		/* Receive current byte */
 		rx_data[num_rx++] = uart_rcar_read_16(config, SCFRDR);
-	}
 
-	reg_val = uart_rcar_read_16(config, SCFSR);
-	reg_val &= ~(SCFSR_RDF);
-	uart_rcar_write_16(config, SCFSR, reg_val);
+		reg_val = uart_rcar_read_16(config, SCFSR);
+		reg_val &= ~(SCFSR_RDF);
+		uart_rcar_write_16(config, SCFSR, reg_val);
+	}
 
 	return num_rx;
 }


### PR DESCRIPTION
uart: rcar: Fix IRQ flags management
Reset IRQ flag for each byte instead of waiting
for the whole payload to be read/write before
resetting the flag.

FIFO read was broken and was receiving the same byte
infinitely because the flag wasn't reset.

uart: rcar: Fix runtime configure
Calling configure at runtime was creating
unreadable data on the uart pins.

It appeared that disabling Receive and Transmit pins
at configuration as suggested by doc is not a thing
to do at runtime but only at initialization.

This commit is then moving this part to the init
function in order to able both a good initialization
phase and a well working "configure at runtime".