### PR TITLE
Iotbzh/aymeric/irq uart fix 2.6 into renesas-v2.6

### DIFF
--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -298,12 +298,12 @@ static int uart_rcar_fifo_fill(const struct device *dev,
 		/* Send current byte */
 		uart_rcar_write_8(config, SCFTDR, tx_data[num_tx]);
 
+		reg_val = uart_rcar_read_16(config, SCFSR);
+		reg_val &= ~(SCFSR_TDFE | SCFSR_TEND);
+		uart_rcar_write_16(config, SCFSR, reg_val);
+
 		num_tx++;
 	}
-
-	reg_val = uart_rcar_read_16(config, SCFSR);
-	reg_val &= ~(SCFSR_TDFE | SCFSR_TEND);
-	uart_rcar_write_16(config, SCFSR, reg_val);
 
 	return num_tx;
 }
@@ -319,11 +319,11 @@ static int uart_rcar_fifo_read(const struct device *dev, uint8_t *rx_data,
 	       (uart_rcar_read_16(config, SCFSR) & SCFSR_RDF)) {
 		/* Receive current byte */
 		rx_data[num_rx++] = uart_rcar_read_16(config, SCFRDR);
-	}
 
-	reg_val = uart_rcar_read_16(config, SCFSR);
-	reg_val &= ~(SCFSR_RDF);
-	uart_rcar_write_16(config, SCFSR, reg_val);
+		reg_val = uart_rcar_read_16(config, SCFSR);
+		reg_val &= ~(SCFSR_RDF);
+		uart_rcar_write_16(config, SCFSR, reg_val);
+	}
 
 	return num_rx;
 }


### PR DESCRIPTION
uart: rcar: Fix IRQ flags management
Reset IRQ flag for each byte instead of waiting
for the whole payload to be read/write before
resetting the flag.

FIFO read was broken and was receiving the same byte
infinitely because the flag wasn't reset.

uart: rcar: Fix runtime configure
Calling configure at runtime was creating
unreadable data on the uart pins.

It appeared that disabling Receive and Transmit pins
at configuration as suggested by doc is not a thing
to do at runtime but only at initialization.

This commit is then moving this part to the init
function in order to able both a good initialization
phase and a well working "configure at runtime".