### PR TITLE
Iotbzh/for upstream/add pwm

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -336,6 +336,7 @@
 /drivers/pwm/pwm_shell.c                  @henrikbrixandersen
 /drivers/pwm/*gecko*                      @sun681
 /drivers/pwm/*it8xxx2*                    @RuibinChang
+/drivers/pwm/*rcar*                       @pmarzin
 /drivers/regulator/*pmic*                 @danieldegrasse
 /drivers/sensor/                          @MaureenHelm
 /drivers/sensor/ams_iAQcore/              @alexanderwachter

--- a/boards/arm/rcar_h3ulcb/doc/rcar_h3ulcb.rst
+++ b/boards/arm/rcar_h3ulcb/doc/rcar_h3ulcb.rst
@@ -62,6 +62,8 @@ Here is the current supported features when running Zephyr Project on the R-Car 
 +-----------+------------------------------+--------------------------------+
 | I2C       | i2c                          | interrupt driven               |
 +-----------+------------------------------+--------------------------------+
+| PWM       | pwm                          | All channels                   |
++-----------+------------------------------+--------------------------------+
 
 It's also currently possible to write on the ram console.
 
@@ -165,6 +167,13 @@ H3ULCB board provides two I2C buses. Unfortunately direct access to these buses 
 I2C is mainly used to manage and power on multiple of onboard chips on the H3ULCB and Kingfisher daughter board.
 
 Embedded I2C devices and I/O expanders are not yet supported. The current I2C support therefore does not make any devices available to the user at this time.
+
+PWM
+---
+
+ULCB boards provide one PWM controller with a maximum of 7 channels [0..6]. H3ULCB does provide the pwm0 from test pin CP8 only.
+
+The Kingfisher daughter board is providing the pwm4 channel on the LVDS CN7 connector. Then LVDS backlight could be supported with this PWM driver on Kingfisher through 4th channel.
 
 Programming and Debugging
 *************************

--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7-pinctrl.dtsi
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7-pinctrl.dtsi
@@ -30,4 +30,8 @@
 	scif2_data_a_rx_default: scif2_data_a_rx_default {
 		pin = <PIN_RX2_A FUNC_RX2_A>;
 	};
+
+	pwm0_pin_out: pwm0_pin_out {
+		pin = <PIN_PWM0 FUNC_PWM0>;
+	};
 };

--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
@@ -51,6 +51,12 @@
 	status = "okay";
 };
 
+&pwm0 {
+	pinctrl-0 = <&pwm0_pin_out>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &can0 {
 	pinctrl-0 = <&can0_data_a_tx_default &can0_data_a_rx_default>;
 	pinctrl-names = "default";

--- a/drivers/clock_control/clock_control_rcar_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_rcar_cpg_mssr.c
@@ -46,6 +46,7 @@ static const uint16_t srcr[] = {
 #define CANFDCKCR_DIVIDER_MASK    0x1FF
 
 #define S3D4_CLK_RATE             66600000
+#define S0D12_CLK_RATE            66600000
 
 static void cpg_write(const struct rcar_mssr_config *config,
 		      uint32_t reg, uint32_t val)
@@ -189,6 +190,9 @@ static int cpg_get_rate(const struct device *dev,
 		break;
 	case CPG_CORE_CLK_S3D4:
 		*rate = S3D4_CLK_RATE;
+		break;
+	case CPG_CORE_CLK_S0D12:
+		*rate = S0D12_CLK_RATE;
 		break;
 	default:
 		ret = -ENOTSUP;

--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -24,6 +24,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_XLNX_AXI_TIMER	pwm_xlnx_axi_timer.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_MCUX_PWT 	pwm_mcux_pwt.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_GECKO   pwm_gecko.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_GD32 pwm_gd32.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_RCAR		pwm_rcar.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   pwm_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_CAPTURE pwm_capture.c)

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -71,4 +71,6 @@ source "drivers/pwm/Kconfig.gecko"
 
 source "drivers/pwm/Kconfig.gd32"
 
+source "drivers/pwm/Kconfig.rcar"
+
 endif # PWM

--- a/drivers/pwm/Kconfig.rcar
+++ b/drivers/pwm/Kconfig.rcar
@@ -1,0 +1,13 @@
+# Reneas R-Car PWM configuration options
+
+# Copyright (c) 2022 IoT.bzh
+# SPDX-License-Identifier: Apache-2.0
+
+DT_COMPAT_RENESAS_RCAR_PWM := renesas,rcar-pwm
+
+config PWM_RCAR
+	bool "Renesas R-Car PWM Driver"
+	default $(dt_compat_enabled,$(DT_COMPAT_RENESAS_RCAR_PWM))
+	depends on SOC_FAMILY_RCAR
+	help
+	  Enable Renesas R-Car PWM Driver.

--- a/drivers/pwm/pwm_rcar.c
+++ b/drivers/pwm/pwm_rcar.c
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2022 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT renesas_rcar_pwm
+
+#include <errno.h>
+#include <device.h>
+#include <devicetree.h>
+#include <soc.h>
+#include <drivers/pwm.h>
+#include <drivers/clock_control.h>
+#include <drivers/clock_control/rcar_clock_control.h>
+#include <drivers/pinctrl.h>
+
+#define LOG_LEVEL CONFIG_PWM_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(pwm_rcar);
+
+/* Helper macros for PWM */
+#define DEV_PWM_CFG(dev)        ((const struct pwm_rcar_cfg *)(dev)->config)
+#define DEV_PWM_DATA(dev)       ((struct pwm_rcar_data *)(dev)->data)
+
+/* PWM Controller capabilities */
+#define RCAR_PWM_MAX_CYCLE      1023U
+#define RCAR_PWM_MAX_DIV        24U
+
+/* Registers */
+#define RCAR_PWM_CR             0x00            /* PWM Control Register */
+#define RCAR_PWM_CNT            0x04            /* PWM Count Register */
+
+/* PWMCR (PWM Control Register) */
+#define RCAR_PWM_CR_CC_MASK             0x000f0000      /* Clock Control */
+#define RCAR_PWM_CR_CC_SHIFT            16
+#define RCAR_PWM_CR_CCMD                BIT(15)         /* Clock Control Frequency Division Mode */
+#define RCAR_PWM_CR_SYNC                BIT(11)
+#define RCAR_PWM_CR_SS                  BIT(4)          /* Single Pulse Output */
+#define RCAR_PWM_CR_EN                  BIT(0)          /* Channel Enable */
+
+/* PWMCNT (PWM Count Register) */
+#define RCAR_PWM_CNT_CYC_MASK           0x03ff0000      /* PWM Cycle */
+#define RCAR_PWM_CNT_CYC_SHIFT          16
+#define RCAR_PWM_CNT_PH_MASK            0x000003ff      /* PWM High-Level Period */
+#define RCAR_PWM_CNT_PH_SHIFT           0
+
+struct pwm_rcar_cfg {
+	uint32_t reg_addr;
+	const struct device *clock_dev;
+	struct rcar_cpg_clk core_clk;
+	struct rcar_cpg_clk mod_clk;
+	const struct pinctrl_dev_config *pcfg;
+};
+
+struct pwm_rcar_data {
+	uint32_t clk_rate;
+};
+
+static uint32_t pwm_rcar_read(const struct pwm_rcar_cfg *config,
+			      uint32_t offs)
+{
+	return sys_read32(config->reg_addr + offs);
+}
+
+static void pwm_rcar_write(const struct pwm_rcar_cfg *config,
+			   uint32_t offs, uint32_t value)
+{
+	sys_write32(value, config->reg_addr + offs);
+}
+
+static void pwm_rcar_write_bit(const struct pwm_rcar_cfg *config,
+			       uint32_t offs, uint32_t bits, bool value)
+{
+	uint32_t reg_val = pwm_rcar_read(config, offs);
+
+	if (value) {
+		reg_val |= bits;
+	} else {
+		reg_val &= ~(bits);
+	}
+
+	pwm_rcar_write(config, offs, reg_val);
+}
+
+static int pwm_rcar_update_clk(const struct pwm_rcar_cfg *config, uint32_t pwm,
+			       uint32_t *period_cycles, uint32_t *pulse_cycles)
+{
+	uint32_t reg_val, power, diviser;
+
+	power = pwm_rcar_read(config, RCAR_PWM_CR) & (RCAR_PWM_CR_CC_MASK | RCAR_PWM_CR_CCMD);
+	power = power >> (RCAR_PWM_CR_CC_SHIFT - 1);
+	diviser = 1 << power;
+
+	LOG_DBG("Found old diviser : 2^%d=%d", power, diviser);
+
+	/* Looking for the best possible clock diviser */
+	if (*period_cycles > RCAR_PWM_MAX_CYCLE) {
+		/* Reducing clock speed */
+		while (*period_cycles > RCAR_PWM_MAX_CYCLE) {
+			diviser *= 2;
+			*period_cycles /= 2;
+			*pulse_cycles /= 2;
+			power++;
+			if (power > RCAR_PWM_MAX_DIV) {
+				return -ENOTSUP;
+			}
+		}
+	} else {
+		/* Increasing clock speed */
+		while (*period_cycles < (RCAR_PWM_MAX_CYCLE / 2)) {
+			if (power == 0) {
+				return -ENOTSUP;
+			}
+			diviser /= 2;
+			*period_cycles *= 2;
+			*pulse_cycles *= 2;
+			power--;
+		}
+	}
+	LOG_DBG("Found new diviser : 2^%d=%d\n", power, diviser);
+
+	/* Set new clock Diviser */
+	reg_val = pwm_rcar_read(config, RCAR_PWM_CR);
+	reg_val &= ~(RCAR_PWM_CR_CC_MASK | RCAR_PWM_CR_CCMD);
+	reg_val |= (power << (RCAR_PWM_CR_CC_SHIFT - 1));
+	pwm_rcar_write(config, RCAR_PWM_CR, reg_val);
+
+	return 0;
+}
+
+static int pwm_rcar_pin_set(const struct device *dev, uint32_t pwm,
+			    uint32_t period_cycles, uint32_t pulse_cycles,
+			    pwm_flags_t flags)
+{
+	const struct pwm_rcar_cfg *config = DEV_PWM_CFG(dev);
+	uint32_t reg_val;
+	int ret = 0;
+
+	if (pwm != 0) {
+		return -ENOTSUP;
+	}
+
+	if (flags != PWM_POLARITY_NORMAL) {
+		return -ENOTSUP;
+	}
+
+	/* Prohibiten values */
+	if (period_cycles == 0U || pulse_cycles == 0U ||
+	    pulse_cycles > period_cycles) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("enabled=pwm%d, pulse_cycles=%d, period_cycles=%d,"
+		" duty_cycle=%d", ((config->reg_addr & 0x0000f000) >> 3), pulse_cycles,
+		period_cycles, (pulse_cycles * 100U / period_cycles));
+
+	/* Disable PWM */
+	pwm_rcar_write_bit(config, RCAR_PWM_CR, RCAR_PWM_CR_EN, false);
+
+	/* Set continuous mode */
+	pwm_rcar_write_bit(config, RCAR_PWM_CR, RCAR_PWM_CR_SS, false);
+
+	/* Enable SYNC mode */
+	pwm_rcar_write_bit(config, RCAR_PWM_CR, RCAR_PWM_CR_SYNC, true);
+
+	/*
+	 * Set clock counter according to the requested period_cycles
+	 * if period_cycles is less than half of the counter, then the
+	 * clock diviser could be updated as the diviser is a modulo 2.
+	 */
+	if (period_cycles > RCAR_PWM_MAX_CYCLE ||
+	    period_cycles < (RCAR_PWM_MAX_CYCLE / 2)) {
+		LOG_DBG("Adapting frequency diviser...");
+		ret = pwm_rcar_update_clk(config, pwm, &period_cycles, &pulse_cycles);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	/* Set total period cycle */
+	reg_val = pwm_rcar_read(config, RCAR_PWM_CNT);
+	reg_val &= ~(RCAR_PWM_CNT_CYC_MASK);
+	reg_val |= (period_cycles << RCAR_PWM_CNT_CYC_SHIFT);
+	pwm_rcar_write(config, RCAR_PWM_CNT, reg_val);
+
+	/* Set high level period cycle */
+	reg_val = pwm_rcar_read(config, RCAR_PWM_CNT);
+	reg_val &= ~(RCAR_PWM_CNT_PH_MASK);
+	reg_val |= (pulse_cycles << RCAR_PWM_CNT_PH_SHIFT);
+	pwm_rcar_write(config, RCAR_PWM_CNT, reg_val);
+
+	/* Enable PWM */
+	pwm_rcar_write_bit(config, RCAR_PWM_CR, RCAR_PWM_CR_EN, true);
+
+	return ret;
+}
+
+static int pwm_rcar_get_cycles_per_sec(const struct device *dev,
+				       uint32_t pwm,
+				       uint64_t *cycles)
+{
+	const struct pwm_rcar_cfg *config = DEV_PWM_CFG(dev);
+	struct pwm_rcar_data *data = DEV_PWM_DATA(dev);
+	uint32_t diviser;
+
+	if (pwm != 0) {
+		return -ENOTSUP;
+	}
+
+	diviser = pwm_rcar_read(config, RCAR_PWM_CR) & (RCAR_PWM_CR_CC_MASK | RCAR_PWM_CR_CCMD);
+	diviser = diviser >> (RCAR_PWM_CR_CC_SHIFT - 1);
+	*cycles = data->clk_rate >> diviser;
+
+	LOG_DBG("Actual division: %d and Frequency: %d Hz", diviser, (uint32_t) *cycles);
+
+	return 0;
+}
+
+static int pwm_rcar_init(const struct device *dev)
+{
+	const struct pwm_rcar_cfg *config = DEV_PWM_CFG(dev);
+	struct pwm_rcar_data *data = DEV_PWM_DATA(dev);
+	int ret;
+
+	/* Configure dt provided device signals when available */
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = clock_control_on(config->clock_dev,
+			       (clock_control_subsys_t *)&config->mod_clk);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = clock_control_get_rate(config->clock_dev,
+				     (clock_control_subsys_t *)&config->core_clk,
+				     &data->clk_rate);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static const struct pwm_driver_api pwm_rcar_driver_api = {
+	.pin_set = pwm_rcar_pin_set,
+	.get_cycles_per_sec = pwm_rcar_get_cycles_per_sec,
+};
+
+/* Device Instantiation */
+#define PWM_DEVICE_RCAR_INIT(n)						       \
+	PINCTRL_DT_INST_DEFINE(n);					       \
+	static const struct pwm_rcar_cfg pwm_rcar_cfg_##n = {		       \
+		.reg_addr = DT_INST_REG_ADDR(n),			       \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		       \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	       \
+		.mod_clk.module =					       \
+			DT_INST_CLOCKS_CELL_BY_IDX(n, 0, module),	       \
+		.mod_clk.domain =					       \
+			DT_INST_CLOCKS_CELL_BY_IDX(n, 0, domain),	       \
+		.core_clk.module =					       \
+			DT_INST_CLOCKS_CELL_BY_IDX(n, 1, module),	       \
+		.core_clk.domain =					       \
+			DT_INST_CLOCKS_CELL_BY_IDX(n, 1, domain),	       \
+	};								       \
+	static struct pwm_rcar_data pwm_rcar_data_##n;			       \
+	DEVICE_DT_INST_DEFINE(n,					       \
+			      pwm_rcar_init,				       \
+			      NULL,					       \
+			      &pwm_rcar_data_##n,			       \
+			      &pwm_rcar_cfg_##n,			       \
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      &pwm_rcar_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_RCAR_INIT)

--- a/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
@@ -10,6 +10,7 @@
 #include <dt-bindings/clock/renesas_rcar_cpg.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	cpus {
@@ -68,6 +69,76 @@
 		pfc: pin-controller@e6060000 {
 			compatible = "renesas,rcar-pfc";
 			reg = <0xe6060000 0x50c>;
+		};
+
+		pwm0: pwm@e6e30000 {
+			compatible = "renesas,rcar-pwm";
+			reg = <0xe6e30000 0x8>;
+			#pwm-cells = <2>;
+			clocks = <&cpg CPG_MOD 523>,
+				<&cpg CPG_CORE CPG_CORE_CLK_S0D12>;
+			status = "disabled";
+			label = "pwm0";
+		};
+
+		pwm1: pwm@e6e31000 {
+			compatible = "renesas,rcar-pwm";
+			reg = <0xe6e31000 0x8>;
+			#pwm-cells = <2>;
+			clocks = <&cpg CPG_MOD 523>,
+				<&cpg CPG_CORE CPG_CORE_CLK_S0D12>;
+			status = "disabled";
+			label = "pwm1";
+		};
+
+		pwm2: pwm@e6e32000 {
+			compatible = "renesas,rcar-pwm";
+			reg = <0xe6e32000 0x8>;
+			#pwm-cells = <2>;
+			clocks = <&cpg CPG_MOD 523>,
+				<&cpg CPG_CORE CPG_CORE_CLK_S0D12>;
+			status = "disabled";
+			label = "pwm2";
+		};
+
+		pwm3: pwm@e6e33000 {
+			compatible = "renesas,rcar-pwm";
+			reg = <0xe6e33000 0x8>;
+			#pwm-cells = <2>;
+			clocks = <&cpg CPG_MOD 523>,
+				<&cpg CPG_CORE CPG_CORE_CLK_S0D12>;
+			status = "disabled";
+			label = "pwm3";
+		};
+
+		pwm4: pwm@e6e34000 {
+			compatible = "renesas,rcar-pwm";
+			reg = <0xe6e34000 0x8>;
+			#pwm-cells = <2>;
+			clocks = <&cpg CPG_MOD 523>,
+				<&cpg CPG_CORE CPG_CORE_CLK_S0D12>;
+			status = "disabled";
+			label = "pwm4";
+		};
+
+		pwm5: pwm@e6e35000 {
+			compatible = "renesas,rcar-pwm";
+			reg = <0xe6e35000 0x8>;
+			#pwm-cells = <2>;
+			clocks = <&cpg CPG_MOD 523>,
+				<&cpg CPG_CORE CPG_CORE_CLK_S0D12>;
+			status = "disabled";
+			label = "pwm5";
+		};
+
+		pwm6: pwm@e6e36000 {
+			compatible = "renesas,rcar-pwm";
+			reg = <0xe6e36000 0x8>;
+			#pwm-cells = <2>;
+			clocks = <&cpg CPG_MOD 523>,
+				<&cpg CPG_CORE CPG_CORE_CLK_S0D12>;
+			status = "disabled";
+			label = "pwm6";
 		};
 
 		cmt0: timer@e60f0500 {

--- a/dts/bindings/pwm/renesas,rcar-pwm.yaml
+++ b/dts/bindings/pwm/renesas,rcar-pwm.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022, IoT.bzh
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas R-Car PWM controller
+
+compatible: "renesas,rcar-pwm"
+
+include: [pwm-controller.yaml, pinctrl-device.yaml, base.yaml]
+
+properties:
+    "#pwm-cells":
+      const: 2
+
+pwm-cells:
+  - channel
+  - flags

--- a/include/dt-bindings/clock/renesas_rcar_cpg.h
+++ b/include/dt-bindings/clock/renesas_rcar_cpg.h
@@ -12,5 +12,6 @@
 
 #define CPG_CORE_CLK_CANFD              0       /* CANFD clock */
 #define CPG_CORE_CLK_S3D4               1       /* S3D4 Clock */
+#define CPG_CORE_CLK_S0D12              2       /* S0D12 Clock */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RCAR_CPG_MSSR_H_ */


### PR DESCRIPTION
Test a PR into iotbzh/main to prepare integration of R-Car PWM driver.

Tested on H3ULCB with pwm0 and pwm4 with blinky_pwm demo. See bellow picture (for fun).
![PWM_blinky_test2](https://user-images.githubusercontent.com/48442493/152836296-4ea84fe0-89f7-4841-9b64-f8e5c989d99b.png)